### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -116,8 +116,7 @@ def archive_context(filename):
 
 def _do_download(version, download_base, to_dir, download_delay):
     """Download Setuptools."""
-    egg = os.path.join(to_dir, 'setuptools-%s-py%d.%d.egg'
-                       % (version, sys.version_info[0], sys.version_info[1]))
+    egg = os.path.join(to_dir, 'setuptools-{0!s}-py{1:d}.{2:d}.egg'.format(version, sys.version_info[0], sys.version_info[1]))
     if not os.path.exists(egg):
         archive = download_setuptools(version, download_base,
                                       to_dir, download_delay)
@@ -327,7 +326,7 @@ def download_setuptools(
     version = _resolve_version(version)
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    zip_name = "setuptools-%s.zip" % version
+    zip_name = "setuptools-{0!s}.zip".format(version)
     url = download_base + zip_name
     saveto = os.path.join(to_dir, zip_name)
     if not os.path.exists(saveto):  # Avoid repeated downloads

--- a/respy/python/simulate/simulate_auxiliary.py
+++ b/respy/python/simulate/simulate_auxiliary.py
@@ -22,7 +22,7 @@ def write_info(respy_obj, data_frame):
     if len(fname_split) > 1:
         fname = '.'.join(fname_split[:-1]) + '.info'
     else:
-        fname = '%s' % file_sim + '.info'
+        fname = '{0!s}'.format(file_sim) + '.info'
 
     # Write information to file
     with open(fname, 'w') as file_:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:restudToolbox:package?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:restudToolbox:package?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)